### PR TITLE
add support for pull_request event reference

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1251,7 +1251,12 @@ const core = __webpack_require__(633);
 const { GitHub, context } = __webpack_require__(479);
 
 async function main() {
-  const ref = core.getInput('ref') || context.ref || context.sha;
+  const prRef =
+    context.payload &&
+    context.payload.pull_request &&
+    context.payload.pull_request.head &&
+    context.payload.pull_request.head.sha;
+  const ref = core.getInput("ref") || prRef || context.ref || context.sha;
   const task = core.getInput('task', { required: true });
   const auto_merge = core.getInput('auto_merge') === 'true';
   const environment = core.getInput('environment', { required: true });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@ const core = require('@actions/core');
 const { GitHub, context } = require('@actions/github');
 
 async function main() {
-  const ref = core.getInput('ref') || context.ref || context.sha;
+  const prRef =
+    context.payload &&
+    context.payload.pull_request &&
+    context.payload.pull_request.head &&
+    context.payload.pull_request.head.sha;
+  const ref = core.getInput('ref') || prRef || context.ref || context.sha;
   const task = core.getInput('task', { required: true });
   const auto_merge = core.getInput('auto_merge') === 'true';
   const environment = core.getInput('environment', { required: true });


### PR DESCRIPTION
when using the pull_request event, the sha is referenced
from the pull_request prop in the event, otherwise you
get a ghost commit produced by github and an (Unknown Event) queued

https://github.community/t/queued-unknown-event-actions-by-ghost/18377/2