### PR TITLE
Update Node to v 16 since v12 is deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ outputs:
     description: The API url of the deployment statuses.
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: avakar/create-deployment`